### PR TITLE
Localize README and auto-update site

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -1,0 +1,50 @@
+name: Update Docs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  append-log:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Append commit to updates
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          DATE=$(date -u +%Y-%m-%d)
+          node - "$DATE" "$SHORT_SHA" "$COMMIT_MSG" <<'NODE'
+          const [date, sha, msg] = process.argv.slice(2);
+          const fs = require('fs');
+          const file = 'docs/updates.json';
+          const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+          data.push({ date, version: sha, description: msg });
+          fs.writeFileSync(file, JSON.stringify(data, null, 2));
+NODE
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@github.com'
+          git add docs/updates.json
+          git commit -m "Update docs with $SHORT_SHA [skip ci]" || echo "No changes"
+          git push
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs
+
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+        with:
+          artifact_name: github-pages

--- a/README-en.md
+++ b/README-en.md
@@ -1,0 +1,41 @@
+# 🚗 Travelbot
+
+**Travelbot** is a location-aware roadtrip companion powered by AI. It runs on an Android phone and speaks every ~15 minutes with sarcastic or informative commentary in the voice of “Henk”, a grumpy Amsterdammer from the Jordaan.
+
+This repo contains:
+- ✅ A Flask backend (`app.py`) that receives location data and generates a funny Dutch remark using OpenAI.
+- ✅ A minimal Android app that sends location data and plays the TTS response.
+- ✅ GitHub Codespaces support — no local setup required!
+
+## 🧠 What does it do?
+
+1. The Android app sends GPS coordinates to the `/comment` endpoint.
+2. The backend uses Wikipedia and GPT to generate a characterful Dutch response.
+3. The app speaks it aloud using Text-to-Speech.
+
+## 🚀 Getting Started in Codespaces
+
+1. Click **“Use this template”** or open this repo in GitHub.
+2. Click **“Code > Codespaces > Create new codespace”**.
+3. Wait for it to set up (~1 min).
+4. Run the backend:
+
+```bash
+python app.py
+```
+
+Your backend is now live at `http://localhost:5000` (forwarded).
+
+## 🔑 Set your API key
+
+In `.bashrc` or terminal:
+
+```bash
+export OPENAI_API_KEY=sk-xxx
+```
+
+Or add it via Codespaces secrets.
+
+## 📱 Android
+
+Install the app from `/app/` onto your phone. It will call the backend and speak Henk’s remarks.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,41 @@
 # 🚗 Travelbot
 
-**Travelbot** is a location-aware roadtrip companion powered by AI. It runs on an Android phone and speaks every ~15 minutes with sarcastic or informative commentary in the voice of “Henk”, a grumpy Amsterdammer from the Jordaan.
+**Travelbot** is een locatiebewuste reisgenoot voor onderweg. Deze versie van de README is in het Nederlands geschreven. Wil je liever de Engelse uitleg lezen? Ga dan naar [README-en.md](README-en.md).
 
-This repo contains:
-- ✅ A Flask backend (`app.py`) that receives location data and generates a funny Dutch remark using OpenAI.
-- ✅ A minimal Android app that sends location data and plays the TTS response.
-- ✅ GitHub Codespaces support — no local setup required!
+Deze repository bevat:
+- ✅ Een Flask-backend (`app.py`) dat locatiegegevens ontvangt en een grappige opmerking genereert via OpenAI.
+- ✅ Een minimale Android-app die de locatie verstuurt en het antwoord via TTS voorleest.
+- ✅ Ondersteuning voor GitHub Codespaces – geen lokale installatie nodig!
 
-## 🧠 What does it do?
+## 🧠 Wat doet het?
 
-1. The Android app sends GPS coordinates to the `/comment` endpoint.
-2. The backend uses Wikipedia and GPT to generate a characterful Dutch response.
-3. The app speaks it aloud using Text-to-Speech.
+1. De Android-app stuurt GPS-coördinaten naar de endpoint `/comment`.
+2. De backend gebruikt Wikipedia en GPT om een karakteristieke Nederlandse reactie te maken.
+3. De app leest deze reactie hardop voor met Text-to-Speech.
 
-## 🚀 Getting Started in Codespaces
+## 🚀 Aan de slag in Codespaces
 
-1. Click **“Use this template”** or open this repo in GitHub.
-2. Click **“Code > Codespaces > Create new codespace”**.
-3. Wait for it to set up (~1 min).
-4. Run the backend:
+1. Klik op **"Use this template"** of open deze repo in GitHub.
+2. Kies **"Code > Codespaces > Create new codespace"**.
+3. Wacht tot de omgeving is opgebouwd (~1 min).
+4. Start de backend met:
 
 ```bash
 python app.py
 ```
 
-Your backend is now live at `http://localhost:5000` (forwarded).
+Je backend is vervolgens bereikbaar op `http://localhost:5000` (via port forwarding).
 
-## 🔑 Set your API key
+## 🔑 API-sleutel instellen
 
-In `.bashrc` or terminal:
+Zet je API-sleutel in `.bashrc` of in de terminal:
 
 ```bash
 export OPENAI_API_KEY=sk-xxx
 ```
 
-Or add it via Codespaces secrets.
+Of voeg deze toe via Codespaces secrets.
 
 ## 📱 Android
 
-Install the app from `/app/` onto your phone. It will call the backend and speak Henk’s remarks.
+Installeer de app uit de map `/app/` op je telefoon. De app roept de backend aan en laat Henk vervolgens zijn opmerkingen uitspreken.

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,7 @@
 </head>
 <body>
     <header>
+        <nav>Nederlands | <a href="index_en.html">English</a></nav>
         <h1>📡 Travelbot – Jouw AI-reisgenoot</h1>
         <p>Versie: <span id="current-version">v0.1</span></p>
     </header>

--- a/docs/index_en.html
+++ b/docs/index_en.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Travelbot Documentation</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <nav><a href="index.html">Nederlands</a> | English</nav>
+        <h1>📡 Travelbot – Your AI travel companion</h1>
+        <p>Version: <span id="current-version">v0.1</span></p>
+    </header>
+
+    <section>
+        <h2>🔧 What is Travelbot?</h2>
+        <p>
+            Travelbot is an AI travel buddy for the car. Every ~15 minutes it speaks with a grumpy Amsterdam accent about your surroundings, based on GPS data, Wikipedia and a language model. It runs on an old Android phone.
+        </p>
+    </section>
+
+    <section>
+        <h2>🚀 Installation</h2>
+        <ol>
+            <li>Flash your old Android phone with LineageOS (see README).</li>
+            <li>Install the app from the <code>/app/</code> directory.</li>
+            <li>Start the backend with <code>python backend/app.py</code> (e.g. via Codespaces).</li>
+            <li>Let the app connect to your backend and hear Henk chatter!</li>
+        </ol>
+    </section>
+
+    <section>
+        <h2>📜 Update history</h2>
+        <ul id="update-log">
+            <li>Loading updates...</li>
+        </ul>
+    </section>
+
+    <footer>
+        <p>Travelbot is a project by <strong>mich ligtenberg</strong> – 2025</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -12,6 +12,8 @@ header, section, footer {
 header h1 {
     font-size: 2rem;
 }
+nav { margin-bottom: 1rem; }
+nav a { text-decoration: none; margin-left: .5rem; }
 ul {
     list-style-type: disc;
     padding-left: 1.5rem;


### PR DESCRIPTION
## Summary
- add Dutch README with link to an English version
- create English docs page and language switch
- tweak docs styling
- automate updating `docs/updates.json` and deploying pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781ebc33a883229005a6451e19a3b5