### PR TITLE
Add startup env check for OPENAI key

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,8 @@ import os
 app = Flask(__name__)
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+if not OPENAI_API_KEY:
+    raise RuntimeError("OPENAI_API_KEY environment variable is missing")
 
 @app.route('/comment', methods=['POST'])
 def comment():


### PR DESCRIPTION
## Summary
- ensure the Flask backend fails fast if OPENAI_API_KEY isn't set

## Testing
- `python -m py_compile backend/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783a1979388322a76d575fe6dce103