### PR TITLE
Add offline cache for ApiClient

### DIFF
--- a/app/src/main/java/com/example/travelbot/ApiClient.kt
+++ b/app/src/main/java/com/example/travelbot/ApiClient.kt
@@ -1,19 +1,35 @@
 package com.example.travelbot
 
 import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
 import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
+import java.io.IOException
 import java.lang.Exception
 import java.net.HttpURLConnection
 import java.net.URL
+import kotlin.math.roundToInt
 
 object ApiClient {
+    private const val TAG = "ApiClient"
+    private const val PREFS_NAME = "travelbot_cache"
+
+    private fun cachePrefs(context: Context): SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    private fun cacheKey(lat: Double, lon: Double): String {
+        val rLat = (lat * 100).roundToInt() / 100.0
+        val rLon = (lon * 100).roundToInt() / 100.0
+        return "${'$'}rLat_${'$'}rLon"
+    }
 
     fun sendLocation(context: Context, lat: Double, lon: Double, question: String? = null): String? {
         val baseUrl = Settings.getBackendUrl(context)
         val url = URL("$baseUrl/comment")
+        val key = cacheKey(lat, lon)
         val body = JSONObject().apply {
             put("lat", lat)
             put("lon", lon)
@@ -37,7 +53,18 @@ object ApiClient {
                 }
             }
             val json = JSONObject(response.toString())
-            json.optString("text")
+            val text = json.optString("text")
+            cachePrefs(context).edit().putString(key, text).apply()
+            text
+        } catch (e: IOException) {
+            val cached = cachePrefs(context).getString(key, null)
+            return if (cached != null) {
+                Log.d(TAG, "Gebruik cache voor locatie $key")
+                cached
+            } else {
+                e.printStackTrace()
+                null
+            }
         } catch (e: Exception) {
             e.printStackTrace()
             null


### PR DESCRIPTION
## Summary
- store backend responses per GPS grid in local SharedPreferences
- reuse cached value when the backend can't be reached
- log cache usage

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687965c1cdd88322a9b0ff33b3872fcb