### PR TITLE
Add persona voice profiles

### DIFF
--- a/app/src/main/java/com/example/travelbot/PersonaManager.kt
+++ b/app/src/main/java/com/example/travelbot/PersonaManager.kt
@@ -1,0 +1,45 @@
+package com.example.travelbot
+
+import android.speech.tts.TextToSpeech
+
+/**
+ * Holds all available personas and their voice profiles.
+ */
+object PersonaManager {
+    data class VoiceProfile(
+        val pitch: Float,
+        val speechRate: Float,
+        val voiceName: String? = null
+    )
+
+    data class Persona(
+        val name: String,
+        val style: String,
+        val voice: VoiceProfile
+    )
+
+    private val personas = listOf(
+        Persona(
+            name = "Jordanees",
+            style = "Jordanees",
+            voice = VoiceProfile(pitch = 1.0f, speechRate = 1.0f)
+        ),
+        Persona(
+            name = "Belg",
+            style = "Belg",
+            voice = VoiceProfile(pitch = 1.1f, speechRate = 0.95f)
+        ),
+        Persona(
+            name = "Brabander",
+            style = "Brabander",
+            voice = VoiceProfile(pitch = 0.9f, speechRate = 1.05f)
+        )
+    )
+
+    val defaultPersona: Persona
+        get() = personas.first()
+
+    fun names(): List<String> = personas.map { it.name }
+
+    fun get(name: String): Persona = personas.find { it.name == name } ?: defaultPersona
+}

--- a/app/src/main/java/com/example/travelbot/Settings.kt
+++ b/app/src/main/java/com/example/travelbot/Settings.kt
@@ -11,7 +11,7 @@ object Settings {
 
     private const val DEFAULT_INTERVAL = 15 // minutes
     private const val DEFAULT_URL = "http://10.0.2.2:5000"
-    private const val DEFAULT_PERSONALITY = "Jordanees"
+    private const val DEFAULT_PERSONALITY = PersonaManager.defaultPersona.name
 
     private fun prefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/app/src/main/java/com/example/travelbot/SettingsActivity.kt
+++ b/app/src/main/java/com/example/travelbot/SettingsActivity.kt
@@ -19,7 +19,7 @@ class SettingsActivity : AppCompatActivity() {
         val personaSpinner = findViewById<Spinner>(R.id.personaSpinner)
         val saveButton = findViewById<MaterialButton>(R.id.saveButton)
 
-        val personas = listOf("Jordanees", "Belg", "Brabander")
+        val personas = PersonaManager.names()
         personaSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, personas)
 
         intervalInput.setText(Settings.getInterval(this).toString())

--- a/app/src/main/java/com/example/travelbot/TtsManager.kt
+++ b/app/src/main/java/com/example/travelbot/TtsManager.kt
@@ -1,21 +1,40 @@
 package com.example.travelbot
 
 import android.content.Context
+import android.os.Build
 import android.speech.tts.TextToSpeech
 import java.util.Locale
 
-class TtsManager(context: Context) : TextToSpeech.OnInitListener {
+class TtsManager(private val context: Context) : TextToSpeech.OnInitListener {
 
     private var tts: TextToSpeech = TextToSpeech(context, this)
+    private var currentPersona: String? = null
 
     override fun onInit(status: Int) {
         if (status == TextToSpeech.SUCCESS) {
             tts.language = Locale("nl", "NL")
+            updateVoice()
         }
     }
 
     fun speak(text: String) {
+        if (currentPersona != Settings.getPersonality(context)) {
+            updateVoice()
+        }
         tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "henk")
+    }
+
+    private fun updateVoice() {
+        val persona = PersonaManager.get(Settings.getPersonality(context))
+        currentPersona = persona.name
+        tts.setPitch(persona.voice.pitch)
+        tts.setSpeechRate(persona.voice.speechRate)
+        persona.voice.voiceName?.let { name ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                val voice = tts.voices.firstOrNull { it.name == name }
+                if (voice != null) tts.voice = voice
+            }
+        }
     }
 
     fun shutdown() {


### PR DESCRIPTION
## Summary
- create `PersonaManager` with default personas and voice profiles
- update settings to use the default persona
- populate the persona spinner from `PersonaManager`
- let `TtsManager` switch voice settings on persona change

## Testing
- `python -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_687965fb999c832288c4d0ec70ba30c4