### PR TITLE
Implement quiet mode

### DIFF
--- a/app/src/main/java/com/example/travelbot/CompanionService.kt
+++ b/app/src/main/java/com/example/travelbot/CompanionService.kt
@@ -45,6 +45,7 @@ class CompanionService : Service() {
 
     private fun fetchAndSpeak() {
         val location = LocationProvider.getLocation(this) ?: return
+        QuietMode.updateLocation(location)
 
         val municipality = getMunicipality(location)
         val distance = lastLocation?.distanceTo(location) ?: Float.MAX_VALUE

--- a/app/src/main/java/com/example/travelbot/MainActivity.kt
+++ b/app/src/main/java/com/example/travelbot/MainActivity.kt
@@ -7,12 +7,14 @@ import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import android.widget.TextView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var ttsManager: TtsManager
+    private lateinit var statusText: TextView
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,15 +33,22 @@ class MainActivity : AppCompatActivity() {
         val soundButton = findViewById<Button>(R.id.soundButton)
         val settingsButton = findViewById<Button>(R.id.settingsButton)
         val input = findViewById<EditText>(R.id.questionInput)
+        statusText = findViewById(R.id.sleepStatus)
+
+        updateStatus()
 
         askButton.setOnClickListener {
             val question = input.text.toString()
             val loc = LocationProvider.getLocation(this)
             if (loc != null && question.isNotBlank()) {
+                QuietMode.updateLocation(loc)
                 Thread {
                     val response = ApiClient.sendLocation(this, loc.latitude, loc.longitude, question)
                     if (response != null) {
-                        runOnUiThread { input.text.clear() }
+                        runOnUiThread {
+                            input.text.clear()
+                            updateStatus()
+                        }
                         ttsManager.speak(response)
                     }
                 }.start()
@@ -52,6 +61,19 @@ class MainActivity : AppCompatActivity() {
 
         soundButton.setOnClickListener {
             startActivity(Intent(this, SoundboardActivity::class.java))
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updateStatus()
+    }
+
+    private fun updateStatus() {
+        statusText.text = if (QuietMode.isSleeping(this)) {
+            getString(R.string.status_sleeping)
+        } else {
+            getString(R.string.status_awake)
         }
     }
 

--- a/app/src/main/java/com/example/travelbot/QuietMode.kt
+++ b/app/src/main/java/com/example/travelbot/QuietMode.kt
@@ -1,0 +1,25 @@
+package com.example.travelbot
+
+import android.content.Context
+import android.location.Location
+import java.util.Calendar
+
+object QuietMode {
+    private var lastLocation: Location? = null
+    private var lastMoveTime: Long = System.currentTimeMillis()
+
+    fun updateLocation(loc: Location) {
+        if (lastLocation == null || loc.distanceTo(lastLocation) > 10) {
+            lastMoveTime = System.currentTimeMillis()
+        }
+        lastLocation = loc
+    }
+
+    fun isSleeping(context: Context): Boolean {
+        if (!Settings.isQuietModeEnabled(context)) return false
+        val noMovement = System.currentTimeMillis() - lastMoveTime > 10 * 60 * 1000
+        val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+        val night = hour < 7 || hour >= 23
+        return noMovement || night
+    }
+}

--- a/app/src/main/java/com/example/travelbot/Settings.kt
+++ b/app/src/main/java/com/example/travelbot/Settings.kt
@@ -8,10 +8,12 @@ object Settings {
     private const val KEY_INTERVAL = "comment_interval"
     private const val KEY_BACKEND_URL = "backend_url"
     private const val KEY_PERSONALITY = "personality"
+    private const val KEY_QUIET_MODE = "quiet_mode"
 
     private const val DEFAULT_INTERVAL = 15 // minutes
     private const val DEFAULT_URL = "http://10.0.2.2:5000"
     private const val DEFAULT_PERSONALITY = "Jordanees"
+    private const val DEFAULT_QUIET_MODE = false
 
     private fun prefs(context: Context): SharedPreferences {
         return context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -37,5 +39,12 @@ object Settings {
 
     fun setPersonality(context: Context, p: String) {
         prefs(context).edit().putString(KEY_PERSONALITY, p).apply()
+    }
+
+    fun isQuietModeEnabled(context: Context): Boolean =
+        prefs(context).getBoolean(KEY_QUIET_MODE, DEFAULT_QUIET_MODE)
+
+    fun setQuietModeEnabled(context: Context, enabled: Boolean) {
+        prefs(context).edit().putBoolean(KEY_QUIET_MODE, enabled).apply()
     }
 }

--- a/app/src/main/java/com/example/travelbot/SettingsActivity.kt
+++ b/app/src/main/java/com/example/travelbot/SettingsActivity.kt
@@ -17,6 +17,7 @@ class SettingsActivity : AppCompatActivity() {
         val intervalInput = findViewById<TextInputEditText>(R.id.intervalInput)
         val urlInput = findViewById<TextInputEditText>(R.id.urlInput)
         val personaSpinner = findViewById<Spinner>(R.id.personaSpinner)
+        val quietSwitch = findViewById<android.widget.Switch>(R.id.quietSwitch)
         val saveButton = findViewById<MaterialButton>(R.id.saveButton)
 
         val personas = listOf("Jordanees", "Belg", "Brabander")
@@ -25,6 +26,7 @@ class SettingsActivity : AppCompatActivity() {
         intervalInput.setText(Settings.getInterval(this).toString())
         urlInput.setText(Settings.getBackendUrl(this))
         personaSpinner.setSelection(personas.indexOf(Settings.getPersonality(this)))
+        quietSwitch.isChecked = Settings.isQuietModeEnabled(this)
 
         saveButton.setOnClickListener {
             val interval = intervalInput.text.toString().toIntOrNull() ?: 15
@@ -33,6 +35,7 @@ class SettingsActivity : AppCompatActivity() {
             Settings.setInterval(this, interval)
             Settings.setBackendUrl(this, url)
             Settings.setPersonality(this, personality)
+            Settings.setQuietModeEnabled(this, quietSwitch.isChecked)
             finish()
         }
     }

--- a/app/src/main/java/com/example/travelbot/TtsManager.kt
+++ b/app/src/main/java/com/example/travelbot/TtsManager.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import android.speech.tts.TextToSpeech
 import java.util.Locale
 
-class TtsManager(context: Context) : TextToSpeech.OnInitListener {
+class TtsManager(private val ctx: Context) : TextToSpeech.OnInitListener {
 
-    private var tts: TextToSpeech = TextToSpeech(context, this)
+    private var tts: TextToSpeech = TextToSpeech(ctx, this)
 
     override fun onInit(status: Int) {
         if (status == TextToSpeech.SUCCESS) {
@@ -15,6 +15,7 @@ class TtsManager(context: Context) : TextToSpeech.OnInitListener {
     }
 
     fun speak(text: String) {
+        if (QuietMode.isSleeping(ctx)) return
         tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "henk")
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,4 +29,11 @@
         android:layout_height="wrap_content"
         android:text="@string/settings" />
 
+    <TextView
+        android:id="@+id/sleepStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/status_awake" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -34,6 +34,13 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp" />
 
+    <Switch
+        android:id="@+id/quietSwitch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/quiet_mode"
+        android:layout_marginTop="16dp" />
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/saveButton"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,7 @@
     <string name="ask_henk">Stel vraag aan Henk</string>
     <string name="soundboard">Speel soundboard-zin</string>
     <string name="settings">Instellingen</string>
+    <string name="quiet_mode">Rustige modus</string>
+    <string name="status_awake">Status: Wakker</string>
+    <string name="status_sleeping">Status: Slapend</string>
 </resources>


### PR DESCRIPTION
## Summary
- add quiet mode setting and preference helpers
- display a switch for quiet mode in settings
- track GPS movement and time to decide if Travelbot is sleeping
- avoid speaking when sleeping and show status on main screen

## Testing
- `python -m py_compile backend/app.py`
- `pip install flask requests`
- `./gradlew --version` *(fails: Unable to access jarfile)*

------
https://chatgpt.com/codex/tasks/task_e_68796630ab6483229e008bb557851cf4