### PR TITLE
Randomize commentary interval

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,4 +29,5 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.12.0'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.11.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 }


### PR DESCRIPTION
## Summary
- update dependencies to include Kotlin coroutines
- rework `CompanionService` to use coroutines
- introduce jittered delay between 10–20 min for commentary
- restart the jittered timer on large GPS changes

## Testing
- `gradle test --dry-run` *(fails: `org.gradle.api.services.BuildService`)*

------
https://chatgpt.com/codex/tasks/task_e_687966154f6c8322983d2a867f8432be